### PR TITLE
Update to how it is supposed to be done nowadays

### DIFF
--- a/av
+++ b/av
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-import os, atexit, dbus, gobject
+import os, atexit, dbus
+from gi.repository import GLib
 import requests
 from dbus.mainloop import glib
 
@@ -51,5 +52,4 @@ if __name__ == '__main__':
     glib.DBusGMainLoop(set_as_default=True)
     bus = dbus.SystemBus()
     controller = LoginController(bus, av)
-    gobject.MainLoop().run()
-
+    GLib.MainLoop().run()


### PR DESCRIPTION
I was gettng:

```
    gobject.MainLoop().run()
AttributeError: module 'gobject' has no attribute 'MainLoop'
```
and this change fixes it. Not really sure why though:-).